### PR TITLE
fix (sass): apply `process_asset` tag recursively in sass files

### DIFF
--- a/lib/processors/scss.rb
+++ b/lib/processors/scss.rb
@@ -9,8 +9,8 @@ module JekyllAssetPostProcessor
         end
 
         def process(contents, liquid_context)
-            template = Liquid::Template.parse(contents)
-            SassC::Engine.new(template.render(liquid_context), syntax: :scss, style: :compressed).render
+            sass = SassC::Engine.new(contents, syntax: :scss, style: :compressed).render
+            Liquid::Template.parse(sass).render(liquid_context)
         end
 
     end


### PR DESCRIPTION
When a Sass file @imports other Sass files, `process_asset` will only apply to the top-level Sass. For example,

```sass
// a.sass; `alfa.jpg` will be processed.
@import `b`
.alfa { background: url('{% process_asset _assets/alfa.jpg %}'); }
```

```sass
// b.sass; `bravo.jpg` will not be processed as the processor is not
// applied recursively.
.bravo { background: url('{% process_asset _assets/bravo.jpg %}'); }
```

This change applies the post processor after the Liquid Saas has rendered, meaning that tags and assets in Sass dependencies will also be processed.